### PR TITLE
Codacy updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ src/public/assets/svg/*
 !src/public/assets/css/.keep
 !src/public/assets/js/.keep
 !src/public/assets/svg/.keep
+
+.codacy-coverage/**
+codacy-coverage-reporter-assembly.jar
+

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,265 @@
+{
+  "rules": {
+    "string-no-newline": true,
+    "declaration-no-important": null,
+    "keyframe-declaration-no-important": true,
+    "function-calc-no-invalid": null,
+    "function-calc-no-unspaced-operator": true,
+    "function-linear-gradient-no-nonstandard-direction": true,
+    "no-invalid-double-slash-comments": true,
+    "no-duplicate-at-import-rules": true,
+    "font-family-no-duplicate-names": true,
+    "declaration-block-no-duplicate-properties": [
+      true,
+      {
+        "ignore": [
+          "consecutive-duplicates-with-different-values"
+        ]
+      }
+    ],
+    "no-duplicate-selectors": true,
+    "block-no-empty": true,
+    "comment-no-empty": true,
+    "no-empty-first-line": null,
+    "no-empty-source": true,
+    "no-eol-whitespace": true,
+    "no-extra-semicolons": true,
+    "color-no-hex": null,
+    "color-no-invalid-hex": true,
+    "declaration-block-no-redundant-longhand-properties": null,
+    "no-missing-end-of-source-newline": true,
+    "font-family-no-missing-generic-family-keyword": true,
+    "selector-descendant-combinator-no-non-space": true,
+    "selector-no-qualifying-type": null,
+    "shorthand-property-no-redundant-values": null,
+    "function-url-no-scheme-relative": null,
+    "no-descending-specificity": true,
+    "declaration-block-no-shorthand-property-overrides": true,
+    "number-no-trailing-zeros": true,
+    "length-zero-no-unit": true,
+    "no-unknown-animations": null,
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+           "function",
+           "include",
+           "mixin",
+           "return"
+        ]
+      }
+    ],
+    "media-feature-name-no-unknown": true,
+    "property-no-unknown": true,
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-element-no-unknown": true,
+    "selector-type-no-unknown": true,
+    "unit-no-unknown": true,
+    "at-rule-no-vendor-prefix": null,
+    "media-feature-name-no-vendor-prefix": null,
+    "property-no-vendor-prefix": null,
+    "selector-no-vendor-prefix": null,
+    "value-no-vendor-prefix": null,
+    "max-nesting-depth": null,
+    "max-line-length": null,
+    "selector-max-id": null,
+    "function-max-empty-lines": 0,
+    "selector-max-empty-lines": 0,
+    "value-list-max-empty-lines": 0,
+    "max-empty-lines": 1,
+    "selector-max-attribute": null,
+    "selector-max-class": null,
+    "selector-max-combinators": null,
+    "selector-max-compound-selectors": null,
+    "number-max-precision": null,
+    "declaration-block-single-line-max-declarations": 1,
+    "selector-max-pseudo-class": null,
+    "selector-max-type": null,
+    "selector-max-universal": null,
+    "selector-max-specificity": null,
+    "color-named": null,
+    "at-rule-name-newline-after": null,
+    "block-opening-brace-newline-after": "always-multi-line",
+    "at-rule-semicolon-newline-after": "always",
+    "block-closing-brace-newline-after": "always",
+    "declaration-colon-newline-after": "always-multi-line",
+    "function-comma-newline-after": "always-multi-line",
+    "media-query-list-comma-newline-after": "always-multi-line",
+    "selector-list-comma-newline-after": "always",
+    "value-list-comma-newline-after": "always-multi-line",
+    "declaration-block-semicolon-newline-after": "always-multi-line",
+    "block-closing-brace-newline-before": "always-multi-line",
+    "function-comma-newline-before": null,
+    "media-query-list-comma-newline-before": null,
+    "selector-list-comma-newline-before": null,
+    "value-list-comma-newline-before": null,
+    "block-opening-brace-newline-before": null,
+    "declaration-block-semicolon-newline-before": null,
+    "function-parentheses-newline-inside": "always-multi-line",
+    "at-rule-name-space-after": "always-single-line",
+    "selector-attribute-operator-space-after": "never",
+    "declaration-bang-space-after": "never",
+    "block-closing-brace-space-after": null,
+    "media-feature-colon-space-after": "always",
+    "declaration-colon-space-after": "always-single-line",
+    "selector-combinator-space-after": "always",
+    "function-comma-space-after": "always-single-line",
+    "media-query-list-comma-space-after": "always-single-line",
+    "selector-list-comma-space-after": null,
+    "value-list-comma-space-after": "always-single-line",
+    "block-opening-brace-space-after": "always-single-line",
+    "media-feature-range-operator-space-after": "always",
+    "declaration-block-semicolon-space-after": "always-single-line",
+    "selector-attribute-operator-space-before": "never",
+    "declaration-bang-space-before": "always",
+    "block-closing-brace-space-before": "always-single-line",
+    "media-feature-colon-space-before": "never",
+    "declaration-colon-space-before": "never",
+    "selector-combinator-space-before": "always",
+    "function-comma-space-before": "never",
+    "media-query-list-comma-space-before": "never",
+    "selector-list-comma-space-before": "never",
+    "value-list-comma-space-before": "never",
+    "block-opening-brace-space-before": "always",
+    "media-feature-range-operator-space-before": "always",
+    "at-rule-semicolon-space-before": null,
+    "declaration-block-semicolon-space-before": "never",
+    "selector-attribute-brackets-space-inside": "never",
+    "function-parentheses-space-inside": "never-single-line",
+    "media-feature-parentheses-space-inside": "never",
+    "selector-pseudo-class-parentheses-space-inside": "never",
+    "font-weight-notation": null,
+    "number-leading-zero": "always",
+    "declaration-block-trailing-semicolon": "always",
+    "at-rule-empty-line-before": [
+      "always",
+      {
+        "except": [
+          "blockless-after-same-name-blockless",
+          "first-nested"
+        ],
+        "ignore": [
+          "after-comment"
+        ]
+      }
+    ],
+    "comment-empty-line-before": [
+      "always",
+      {
+        "except": [
+          "first-nested"
+        ],
+        "ignore": [
+          "stylelint-commands"
+        ]
+      }
+    ],
+    "custom-property-empty-line-before": [
+      "always",
+      {
+        "except": [
+          "after-custom-property",
+          "first-nested"
+        ],
+        "ignore": [
+          "after-comment",
+          "inside-single-line-block"
+        ]
+      }
+    ],
+    "declaration-empty-line-before": [
+      "always",
+      {
+        "except": [
+          "after-declaration",
+          "first-nested"
+          ],
+      "ignore": [
+        "after-comment",
+        "inside-single-line-block"
+        ]
+      }
+    ],
+    "rule-empty-line-before": [
+      "always-multi-line",
+      {
+        "except": [
+          "first-nested"
+        ],
+        "ignore": [
+          "after-comment"
+        ]
+      }
+    ],
+    "block-closing-brace-empty-line-before": "never",
+    "selector-attribute-quotes": null,
+    "function-url-quotes": null,
+    "unicode-bom": null,
+    "function-whitespace-after": "always",
+    "comment-whitespace-inside": "always",
+    "function-url-scheme-blacklist": null,
+    "at-rule-blacklist": null,
+    "selector-attribute-operator-blacklist": null,
+    "selector-combinator-blacklist": null,
+    "function-blacklist": null,
+    "media-feature-name-blacklist": null,
+    "property-blacklist": null,
+    "declaration-property-unit-blacklist": null,
+    "declaration-property-value-blacklist": null,
+    "selector-pseudo-class-blacklist": null,
+    "selector-pseudo-element-blacklist": null,
+    "unit-blacklist": null,
+    "comment-word-blacklist": null,
+    "selector-id-pattern": null,
+    "selector-class-pattern": null,
+    "custom-media-pattern": null,
+    "custom-property-pattern": null,
+    "keyframes-name-pattern": null,
+    "selector-nested-pattern": null,
+    "at-rule-property-requirelist": null,
+    "function-url-scheme-whitelist": null,
+    "at-rule-whitelist": null,
+    "selector-attribute-operator-whitelist": null,
+    "selector-combinator-whitelist": null,
+    "function-whitelist": null,
+    "media-feature-name-value-whitelist": null,
+    "media-feature-name-whitelist": null,
+    "property-whitelist": null,
+    "declaration-property-unit-whitelist": null,
+    "declaration-property-value-whitelist": null,
+    "selector-pseudo-class-whitelist": null,
+    "selector-pseudo-element-whitelist": null,
+    "unit-whitelist": null,
+    "indentation": 2,
+    "at-rule-name-case": "lower",
+    "function-name-case": [
+      "lower",
+      {
+        "ignoreFunctions": [
+          "breakpoints",
+          "fontFamily",
+          "siteColor",
+          "siteImage",
+          "siteSize"
+        ]
+      }
+    ],
+    "color-hex-case": "lower",
+    "value-keyword-case": null,
+    "media-feature-name-case": "lower",
+    "property-case": "lower",
+    "selector-pseudo-class-case": "lower",
+    "selector-pseudo-element-case": "lower",
+    "selector-type-case": "lower",
+    "unit-case": "lower",
+    "color-function-notation": null,
+    "hue-degree-notation": null,
+    "alpha-value-notation": null,
+    "color-hex-length": "short",
+    "selector-pseudo-element-colon-notation": "double",
+    "string-quotes": null,
+    "time-min-milliseconds": null,
+    "linebreaks": null,
+    "font-family-name-quotes": null
+  }
+}

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -85,7 +85,7 @@
     "declaration-colon-newline-after": "always-multi-line",
     "function-comma-newline-after": "always-multi-line",
     "media-query-list-comma-newline-after": "always-multi-line",
-    "selector-list-comma-newline-after": "always",
+    "selector-list-comma-newline-after": "never",
     "value-list-comma-newline-after": "always-multi-line",
     "declaration-block-semicolon-newline-after": "always-multi-line",
     "block-closing-brace-newline-before": "always-multi-line",

--- a/codesize.xml
+++ b/codesize.xml
@@ -21,7 +21,8 @@
         <properties>
             <property name="exceptions">
                 <value>
-                    \JWT
+                    \Firebase\JWT\JWT,
+                    \Prophecy\Argument
                 </value>
             </property>
         </properties>

--- a/codesize.xml
+++ b/codesize.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<ruleset name="My first PHPMD rule set"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                     http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="
+                     http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>
+        My custom rule set that checks my code...
+    </description>
+
+    <!-- Import all but StaticAccess from cleancode rule set -->
+    <rule ref="rulesets/cleancode.xml">
+        <exclude name="StaticAccess" />
+    </rule>
+    <!-- Set properties for ShortVariable from cleancode rule set -->
+    <rule ref="rulesets/cleancode.xml/StaticAccess">
+        <properties>
+            <property name="exceptions">
+                <value>
+                    \JWT
+                </value>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Import the entire codesize rule set -->
+    <rule ref="rulesets/codesize.xml" />
+
+    <!-- Import the entire controversial rule set -->
+    <rule ref="rulesets/controversial.xml" />
+
+    <!-- Import the entire design rule set -->
+    <rule ref="rulesets/design.xml" />
+
+    <!-- Import the entire unusedcode rule set -->
+    <rule ref="rulesets/unusedcode.xml" />
+
+    <!-- Import all but ShortVariable from naming rule set -->
+    <rule ref="rulesets/naming.xml">
+        <exclude name="ShortVariable" />
+    </rule>
+    <!-- Set properties for ShortVariable from naming rule set -->
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="exceptions">
+                <value>
+                    db
+                </value>
+            </property>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/codesize.xml
+++ b/codesize.xml
@@ -12,6 +12,8 @@
 
     <!-- Import all but StaticAccess from cleancode rule set -->
     <rule ref="rulesets/cleancode.xml">
+        <exclude name="BooleanArgumentFlag" />
+        <exclude name="ElseExpression" />
         <exclude name="StaticAccess" />
     </rule>
     <!-- Set properties for ShortVariable from cleancode rule set -->
@@ -26,13 +28,23 @@
     </rule>
 
     <!-- Import the entire codesize rule set -->
-    <rule ref="rulesets/codesize.xml" />
+    <rule ref="rulesets/codesize.xml">
+        <exclude name="TooManyPublicMethods" />
+    </rule>
 
     <!-- Import the entire controversial rule set -->
-    <rule ref="rulesets/controversial.xml" />
+    <rule ref="rulesets/controversial.xml">
+        <exclude name="CamelCaseClassName" />
+        <exclude name="CamelCaseMethodName" />
+        <exclude name="CamelCaseParameterName" />
+        <exclude name="CamelCasePropertyName" />
+        <exclude name="CamelCaseVariableName" />
+    </rule>
 
     <!-- Import the entire design rule set -->
-    <rule ref="rulesets/design.xml" />
+    <rule ref="rulesets/design.xml">
+        <exclude name="DevelopmentCodeFragment" />
+    </rule>
 
     <!-- Import the entire unusedcode rule set -->
     <rule ref="rulesets/unusedcode.xml" />
@@ -44,12 +56,7 @@
     <!-- Set properties for ShortVariable from naming rule set -->
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>
-            <property name="exceptions">
-                <value>
-                    db,
-                    id
-                </value>
-            </property>
+            <property name="exceptions" value="db,id" />
         </properties>
     </rule>
 

--- a/codesize.xml
+++ b/codesize.xml
@@ -46,7 +46,8 @@
         <properties>
             <property name="exceptions">
                 <value>
-                    db
+                    db,
+                    id
                 </value>
             </property>
         </properties>

--- a/src/classes/DBO.php
+++ b/src/classes/DBO.php
@@ -1052,13 +1052,13 @@ class DBO
         $queryUpdateRound->bindValue(':id', (int) $id2, PDO::PARAM_INT);
         $queryUpdateRound->bindValue(':round_id', (int) $round_id1, PDO::PARAM_INT);
         $queryUpdateRound->bindValue(':location_id', (int) $location_id1, PDO::PARAM_INT);
-        $success = $queryUpdateRound->execute();
+        $queryUpdateRound->execute();
 
         // Put $id1 into $round_id2 and $location_id2
         $queryUpdateRound->bindValue(':id', (int) $id1, PDO::PARAM_INT);
         $queryUpdateRound->bindValue(':round_id', (int) $round_id2, PDO::PARAM_INT);
         $queryUpdateRound->bindValue(':location_id', (int) $location_id2, PDO::PARAM_INT);
-        $sucess = $queryUpdateRound->execute();
+        $queryUpdateRound->execute();
     }
 
     /**

--- a/src/classes/Results.php
+++ b/src/classes/Results.php
@@ -55,7 +55,7 @@ class Results
         $this->fillBooking($rounds, $locations);
         $this->dbo->commit();
 
-        $this->resolveConflicts($rounds, $locations);
+        $this->resolveConflicts($locations);
     }
 
     /**
@@ -83,10 +83,9 @@ class Results
     /**
      * Resolve conflicts with facilitators.  Conflicts might not be resolvable!
      *
-     * @param int $rounds The total number of rounds.
      * @param int $locations The total number locations.
      */
-    private function resolveConflicts($rounds, $locations) {
+    private function resolveConflicts($locations) {
         // Find minimum number of conflicts; limit to $triesLeft
         $conflictArr=$this->dbo->findConflicts($this->logger);
         $conflictIndex = 0;

--- a/src/frontend/scss/Africa.scss
+++ b/src/frontend/scss/Africa.scss
@@ -48,7 +48,7 @@ $site_sizes: (
 );
 
 $site_images: (
-    bof-logo-image: url(/assets/img/ICCM-Africa-logo.png),
+  bof-logo-image: url(/assets/img/ICCM-Africa-logo.png),
 );
 
 $font-family: (

--- a/src/frontend/scss/Americas.scss
+++ b/src/frontend/scss/Americas.scss
@@ -48,7 +48,7 @@ $site_sizes: (
 );
 
 $site_images: (
-    bof-logo-image: url(/assets/img/ICCM-Americas-logo.png),
+  bof-logo-image: url(/assets/img/ICCM-Americas-logo.png),
 );
 
 $font-family: (

--- a/src/frontend/scss/Asia.scss
+++ b/src/frontend/scss/Asia.scss
@@ -47,7 +47,7 @@ $site_sizes: (
 );
 
 $site_images: (
-    bof-logo-image: url(/assets/img/ICCM-Asia-logo.png),
+  bof-logo-image: url(/assets/img/ICCM-Asia-logo.png),
 );
 
 $font-family: (

--- a/src/frontend/scss/Australia.scss
+++ b/src/frontend/scss/Australia.scss
@@ -48,7 +48,7 @@ $site_sizes: (
 );
 
 $site_images: (
-    bof-logo-image: url(/assets/img/ICCM-Australia-logo.png),
+  bof-logo-image: url(/assets/img/ICCM-Australia-logo.png),
 );
 
 $font-family: (

--- a/src/frontend/scss/Europe.scss
+++ b/src/frontend/scss/Europe.scss
@@ -48,7 +48,7 @@ $site_sizes: (
 );
 
 $site_images: (
-    bof-logo-image: url(/assets/img/ICCM-Europe-logo.png),
+  bof-logo-image: url(/assets/img/ICCM-Europe-logo.png),
 );
 
 $font-family: (

--- a/src/frontend/scss/_foot-nav.scss
+++ b/src/frontend/scss/_foot-nav.scss
@@ -6,11 +6,10 @@
   justify-content: space-around;
   list-style-type: none;
   margin: 0;
-  padding: 0;
+  padding: 5px;
   position: fixed;
   width: 100%;
   font-size: 14px;
-  padding: 5px;
 
   li {
     padding: 0;

--- a/src/frontend/scss/_vars.scss
+++ b/src/frontend/scss/_vars.scss
@@ -11,9 +11,9 @@
 }
 
 @function siteImage($i) {
-  @return map-get($site_images, $i)
+  @return map-get($site_images, $i);
 }
 
 @function siteSize($m) {
-  @return map-get($site_sizes, $m)
+  @return map-get($site_sizes, $m);
 }

--- a/src/test/classes/TestAdmin.php
+++ b/src/test/classes/TestAdmin.php
@@ -306,9 +306,6 @@ class TestAdmin extends TestCase
      * @test
      */
     public function updateConfigDownloadsDatabase() {
-        $config = [
-            'loggedin' => true,
-        ];
         $data = [
             'password1' => null,
             'password2' => null,

--- a/src/test/classes/TestAuth.php
+++ b/src/test/classes/TestAuth.php
@@ -461,11 +461,6 @@ class TestAuth extends TestCase
             'user_name' => 'user1',
             'password' => 'password1'
         ];
-        $user = (object) [
-           'id' => 1,
-           'name' => $data['user_name'],
-           'valid' => false
-        ];
 
         $dbo = $this->getMockBuilder(DBO::class)
             ->disableOriginalConstructor()

--- a/src/test/classes/TestDBO.php
+++ b/src/test/classes/TestDBO.php
@@ -149,7 +149,7 @@ class TestDBO extends TestCase
         $sql = "INSERT INTO participant (id, name, password) VALUES";
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '*14E65567ABDB5135D0CFD9A70B3032C179A49EE7')";
             }
             else {
@@ -162,7 +162,7 @@ class TestDBO extends TestCase
         $sql = "INSERT INTO workshop (id, creator_id, name, description, published) VALUES";
         for ($count = 0; $count < $workshops; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, {$id}, 'topic{$count}', 'Description for topic{$count}', 0)";
             }
             else {
@@ -349,10 +349,10 @@ class TestDBO extends TestCase
         $rows = $query->fetchAll(PDO::FETCH_OBJ);
         $this->assertNotFalse($rows);
         $this->assertEquals(count($expected), count($rows));
-        for ($i = 0; $i < count($expected); $i++) {
-            $this->assertEquals($expected[$i][0], $rows[$i]->id);
-            $this->assertEquals($expected[$i][1], $rows[$i]->round_id);
-            $this->assertEquals($expected[$i][2], $rows[$i]->location_id);
+        for ($idx = 0; $idx < count($expected); $idx++) {
+            $this->assertEquals($expected[$idx][0], $rows[$idx]->id);
+            $this->assertEquals($expected[$idx][1], $rows[$idx]->round_id);
+            $this->assertEquals($expected[$idx][2], $rows[$idx]->location_id);
         }
     }
 
@@ -453,8 +453,8 @@ class TestDBO extends TestCase
               ORDER BY participant_id, workshop_id";
         $query = self::$pdo->prepare($sql);
         $query->execute();
-        $wp = $query->fetch(PDO::FETCH_OBJ);
-        $this->assertEquals(1, $wp->leader);
+        $participant = $query->fetch(PDO::FETCH_OBJ);
+        $this->assertEquals(1, $participant->leader);
     }
 
     /**
@@ -515,7 +515,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -538,7 +538,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -568,7 +568,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -591,7 +591,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -614,7 +614,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -637,7 +637,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -660,7 +660,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -731,7 +731,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -762,7 +762,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -817,7 +817,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -839,7 +839,7 @@ class TestDBO extends TestCase
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
-                $id= $count + 100;
+                $id = $count + 100;
                 $sql .= ",({$id}, 'user{$count}', '{$pass}')";
             }
             else {
@@ -948,17 +948,17 @@ EOF;
         // findConflicts returns.
         $bookedWorkshops = [];
         $workshop_id = 101;
-        $i = 0;
+        $idx = 0;
         for ($round = 0; $round < $rounds; $round++) {
             for ($location = 0; $location < $locations; $location++) {
                 if (($round == $rounds - 1) && ($location == 1)) {
-                    $bookedWorkshops[$i] = [1, $round, $location];
+                    $bookedWorkshops[$idx] = [1, $round, $location];
                 }
                 else {
-                    $bookedWorkshops[$i] = [$workshop_id, $round, $location];
+                    $bookedWorkshops[$idx] = [$workshop_id, $round, $location];
                     $workshop_id++;
                 }
-                $i++;
+                $idx++;
             }
         }
         $this->_setBooking($bookedWorkshops);
@@ -982,9 +982,9 @@ EOF;
 
         $conflicts = $conflictsArr['conflicts'];
         $this->assertEquals($expectedInArray, count($conflicts));
-        for ($i = 0; $i < $expectedInArray; $i++) {
-            $this->assertEquals(101, $conflicts[$i]->participant_id);
-            $this->assertEquals($i, $conflicts[$i]->round_id);
+        for ($idx = 0; $idx < $expectedInArray; $idx++) {
+            $this->assertEquals(101, $conflicts[$idx]->participant_id);
+            $this->assertEquals($idx, $conflicts[$idx]->round_id);
         }
     }
 

--- a/src/test/classes/TestLogger.php
+++ b/src/test/classes/TestLogger.php
@@ -47,7 +47,6 @@ class TestLogger extends TestCase
      */
     public function getLogReturnsEmptyAfterGetLog() {
         $message = 'Test message';
-        $expected = $message."\n";
         $logger = new Logger();
         $logger->log($message);
         $logger->getLog();


### PR DESCRIPTION
This is mostly for discussion...

The commits in this pull request do the following:

1) Add codesize.xml to configure PHPMD for Codacy
2) Add .stylelintrc to configure Stylelint for Codacy
3) Minor updates to fix some issues reported by Codacy from one of those tools.

In both cases, the files I created followed the defaults from Codacy, then started making changes.

The changes for PHPMD are:
1) Exclude the ElseExpression rule
2) Add exceptions to the StaticAccess rule for JWT & Prophecy\Argument since they both require static access
3) Add exceptions for `$db` and `$id` in the ShortVariable rule.

The changes for Stylelint are:
1) Add exceptions for at-rule-no-unknown so that it won't complain about `@function`, `@include`, `@mixin`, or `@return`.
2) Add exception for function-name-case so that it won't complain about `breakpoints`, `fontFamily`, `siteColor`, `siteImage`, or `siteSize`.
3) Changed selector-list-comma-newline-after to never -- All of the scss files that use multiple selectors kept them all on one-line, so I figured it's reasonable to have Stylelint assume that's the right way. :)

I know you can configure Codacy through their UI to achieve the above, but by using files in the repo, you can run the tools on your own and see the results without pushing code to github (and configuring your own github repo to use Codacy, which I had to do to test all this).  Additionally, if you're using an IDE like Visual Studio Code and install the extensions for PHPMD and Stylelint, you'll see the same set of issues directly in the IDE as you enter the code. :) The extensions might need some configuration, too, e.g. to tell it how to find the config file for PHPMD, since that's not a standard file name for PHPMD, but it's what Codacy uses, and you can't tell Codacy to use something else, AFAICT. :(

The biggest downside (besides extra files in the repo) is that you have to configure Codacy to use the files through the UI.  The documentation for Codacy suggests that if it finds a configuration file, it'll switch to using it.  In my experience, though, that's not true.  You have to add the configuration file, then go to the Code Patterns section of the Codacy site, select the tool, then click "Configuration file".  And no, it won't re-analyze after making that change, you have to do it manually.  Future commits will use the Configuration file.

I've also had some good success with coverage reporting.  After installing the Codacy coverage tool, it seems the most reliable way to use it is to run the phpunit tests, report coverage, push the repo, and report coverage again.

If we want to keep using Codacy, do we want to consider some sort of CI server to run the unit & integration tests, and report code coverage to Codacy? (**note**: there's really no code coverage for the integration tests; we could add coverage data for the tests themselves, but that seems kinda silly to me)

If we want to keep using Codacy, do we want to create an organization so more people can modify the settings for Codacy for the main repo?