### PR TITLE
fix cypress and unit tests for creating users

### DIFF
--- a/cypress/integration/admin.js
+++ b/cypress/integration/admin.js
@@ -1,11 +1,11 @@
 describe('The admin page', function() {
   before(() => {
     require('../support/reset_database.js').reset()
-    cy.createUser({username: 'user1', password: 'pwd1'})
+    cy.createUser({username: 'user1', password: 'Test123!pwd1', email: 'user1@example.org'})
   })
 
   it('rejects a non-admin user', function() {
-    cy.typeLogin({username: 'user1', password: 'pwd1'})
+    cy.typeLogin({username: 'user1', password: 'Test123!pwd1'})
     cy.request({url: '/admin', failOnStatusCode: false}).then((response) => {
       expect(response.status).to.eq(500)
       expect(response.body).to.eq('you don\'t have permissions for this page')

--- a/cypress/integration/alltopics-nomination.js
+++ b/cypress/integration/alltopics-nomination.js
@@ -26,8 +26,8 @@ describe('In the Nomination stage', function() {
   describe('the All topics page for a non-admin user', function() {
     before(() => {
       resetDB.reset()
-      cy.createUser({username: 'user1', password: 'pwd1'})
-      cy.typeLogin({username: 'user1', password: 'pwd1'})
+      cy.createUser({username: 'user1', password: 'Test123!pwd1', email: 'user1@example.org'})
+      cy.typeLogin({username: 'user1', password: 'Test123!pwd1'})
     })
 
     it('loads successfully', function() {

--- a/cypress/integration/alltopics-voting.js
+++ b/cypress/integration/alltopics-voting.js
@@ -26,8 +26,8 @@ describe('In the Voting stage', function() {
   describe('the All topics page for a non-admin user', function() {
     before(() => {
       resetDB.resetVoting()
-      cy.createUser({username: 'user1', password: 'pwd1'})
-      cy.typeLogin({username: 'user1', password: 'pwd1'})
+      cy.createUser({username: 'user1', password: 'Test123!pwd1', email: 'user1@example.org'})
+      cy.typeLogin({username: 'user1', password: 'Test123!pwd1'})
     })
 
     beforeEach(() => {

--- a/cypress/integration/alltopics.js
+++ b/cypress/integration/alltopics.js
@@ -5,11 +5,11 @@ describe('After the Voting stage', function() {
   describe('the All topics page for a non-admin user', function() {
     before(() => {
       resetDB.resetFinished()
-      cy.createUser({username: 'user1', password: 'pwd1'})
+      cy.createUser({username: 'user1', password: 'Test123!pwd1', email: 'user1@example.org'})
     })
 
     it('loads successfully', function() {
-      cy.typeLogin({username: 'user1', password: 'pwd1'})
+      cy.typeLogin({username: 'user1', password: 'Test123!pwd1'})
       cy.visit('/topics')
     })
 

--- a/cypress/integration/login.js
+++ b/cypress/integration/login.js
@@ -1,7 +1,7 @@
 describe('The login page', function() {
   before(() => {
     require('../support/reset_database.js').reset()
-    cy.createUser({username: 'user1', password: 'pwd1'})
+    cy.createUser({username: 'user1', password: 'Test123!pwd1', email: 'user1@example.org'})
   })
 
   it('loads successfully', function() {

--- a/cypress/integration/logout.js
+++ b/cypress/integration/logout.js
@@ -1,8 +1,8 @@
 describe('The logout page', function() {
   before(() => {
     require('../support/reset_database.js').reset()
-    cy.createUser({username: 'user1', password: 'pwd1'})
-    cy.typeLogin({username: 'user1', password: 'pwd1'})
+    cy.createUser({username: 'user1', password: 'Test123!pwd1', email: 'user1@example.org'})
+    cy.typeLogin({username: 'user1', password: 'Test123!pwd1'})
     cy.getCookie('authtoken').should('have.property', 'value')
   })
 

--- a/cypress/integration/nominate.js
+++ b/cypress/integration/nominate.js
@@ -1,8 +1,8 @@
 describe('In the Nomination stage, the Nominate topic page', function() {
   before(() => {
     require('../support/reset_database.js').reset()
-    cy.createUser({username: 'user1', password: 'pwd1'})
-    cy.typeLogin({username: 'user1', password: 'pwd1'})
+    cy.createUser({username: 'user1', password: 'Test123!pwd1', email: 'user1@example.org'})
+    cy.typeLogin({username: 'user1', password: 'Test123!pwd1'})
   })
 
   beforeEach(() => {
@@ -53,8 +53,8 @@ describe('In the Nomination stage, the Nominate topic page', function() {
 describe('In the Voting stage, the Nominate topic page', function() {
   before(() => {
     require('../support/reset_database.js').resetVoting()
-    cy.createUser({username: 'user1', password: 'pwd1'})
-    cy.typeLogin({username: 'user1', password: 'pwd1'})
+    cy.createUser({username: 'user1', password: 'Test123!pwd1', email: 'user1@example.org'})
+    cy.typeLogin({username: 'user1', password: 'Test123!pwd1'})
   })
 
   it('fails to load', function() {

--- a/cypress/integration/nomination.js
+++ b/cypress/integration/nomination.js
@@ -18,7 +18,7 @@ describe('test nomination stage', function() {
   })
 
   it('nominate topics', function() {
-    cy.typeLogin({username: "user1", password: "pwd1"})
+    cy.typeLogin({username: "user1", password: "Test123!pwd1"})
     var i
     for(i=1; i < 15; i++) {
       create_topic("topic" + i)

--- a/cypress/integration/nomination.js
+++ b/cypress/integration/nomination.js
@@ -13,7 +13,7 @@ describe('test nomination stage', function() {
   it('create users', function() {
     var i
     for(i=1; i < 60; i++) {
-      cy.createUser({username: "user" + i, password: "pwd" + i})
+      cy.createUser({username: "user" + i, password: "Test123!pwd" + i, email: "user" + i + "@example.org"})
     }
   })
 

--- a/cypress/integration/register.js
+++ b/cypress/integration/register.js
@@ -1,7 +1,7 @@
 describe('The register page', function() {
   before(() => {
       require('../support/reset_database.js').reset()
-      cy.createUser({username: 'test2', password: 'pwd2'})
+      cy.createUser({username: 'test2', password: 'Test123!pwd2', email: 'test2@example.org'})
   })
 
   it('loads successfully', function() {

--- a/cypress/integration/voting.js
+++ b/cypress/integration/voting.js
@@ -130,7 +130,7 @@ describe('test voting stage', function() {
   it('cast votes', function() {
     var i
     for(i=1; i < 60; i++) {
-      cy.typeLogin({username: "user" + i, password: "pwd" + i})
+      cy.typeLogin({username: "user" + i, password: "Test123!pwd" + i})
 
       var topic
       for (topic=0; topic < 14; topic++)

--- a/cypress/integration/voting.js
+++ b/cypress/integration/voting.js
@@ -123,7 +123,7 @@ describe('test voting stage', function() {
     var resetDB = require('../support/reset_database.js')
     resetDB.resetVoting()
     for(var i=1; i < 60; i++) {
-      cy.createUser({username: "user" + i, password: "pwd" + i})
+      cy.createUser({username: "user" + i, password: "Test123!pwd" + i, email: 'user1@example.org'})
     }
   })
 

--- a/cypress/integration/voting.js
+++ b/cypress/integration/voting.js
@@ -123,7 +123,7 @@ describe('test voting stage', function() {
     var resetDB = require('../support/reset_database.js')
     resetDB.resetVoting()
     for(var i=1; i < 60; i++) {
-      cy.createUser({username: "user" + i, password: "Test123!pwd" + i, email: 'user1@example.org'})
+      cy.createUser({username: "user" + i, password: "Test123!pwd" + i, email: 'user' + i + '@example.org'})
     }
   })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -34,5 +34,5 @@ Cypress.Commands.add('logout', () => {
 })
 
 Cypress.Commands.add('createUser', (user) => {
-  cy.request('POST', "/new_user", { user_name: user.username, password: user.password })
+  cy.request('POST', "/new_user", { user_name: user.username, password: user.password, email: user.email }).its('body').should('include', 'All topics')
 })

--- a/src/classes/Auth.php
+++ b/src/classes/Auth.php
@@ -96,7 +96,7 @@ class Auth
         else {
             $token = bin2hex(random_bytes(16));
             $id = $this->dbo->addUser($login, $email, $password, $language, $userinfo, $active, $token);
-            if (!is_numeric($id)) {
+            if (!is_numeric($id) && $id !== true) {
                 error_log($id);
                 die('error creating user');
             }

--- a/src/classes/Auth.php
+++ b/src/classes/Auth.php
@@ -27,7 +27,7 @@ class Auth
         $this->cookies = $cookies;
         $this->translator = $translator;
         $this->settings = require __DIR__.'/../../cfg/settings.php';
-        $this->site = $_SERVER['SERVER_NAME'];
+        $this->site = ($_SERVER && array_key_exists('SERVER_NAME',$_SERVER)?$_SERVER['SERVER_NAME':'localhost')];
     }
 
     private function signin($response, $login, $userid) {

--- a/src/classes/Auth.php
+++ b/src/classes/Auth.php
@@ -27,7 +27,7 @@ class Auth
         $this->cookies = $cookies;
         $this->translator = $translator;
         $this->settings = require __DIR__.'/../../cfg/settings.php';
-        $this->site = ($_SERVER && array_key_exists('SERVER_NAME',$_SERVER)?$_SERVER['SERVER_NAME':'localhost')];
+        $this->site = ($_SERVER && array_key_exists('SERVER_NAME',$_SERVER)?$_SERVER['SERVER_NAME']:'localhost');
     }
 
     private function signin($response, $login, $userid) {

--- a/src/classes/Auth.php
+++ b/src/classes/Auth.php
@@ -69,7 +69,7 @@ class Auth
         $login = $data['user_name'];
         $email = $data['email'];
         $password = $data['password'];
-        $language = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+        $language = substr($_SERVER && array_key_exists('HTTP_ACCEPT_LANGUAGE', $_SERVER)?$_SERVER['HTTP_ACCEPT_LANGUAGE']:'en', 0, 2);
         if (array_key_exists('userinfo', $data)) {
             $userinfo = $data['userinfo'];
         } else {

--- a/src/test/classes/TestAuth.php
+++ b/src/test/classes/TestAuth.php
@@ -462,7 +462,7 @@ class TestAuth extends TestCase
         $data = [
             'user_name' => 'user1',
             'email' => 'user1@example.org',
-            'password' => 'password1'
+            'password' => 'Test1234!'
         ];
 
         $dbo = $this->getMockBuilder(DBO::class)

--- a/src/test/classes/TestAuth.php
+++ b/src/test/classes/TestAuth.php
@@ -21,7 +21,7 @@ class TestAuth extends TestCase
      * @covers \ICCM\BOF\Auth::authenticate
      * @test
      */
-    public function authenitcateFailsForBadPassword() {
+    public function authenticateFailsForBadPassword() {
         $data = [
             'user_name' => 'user1',
             'password' => 'password1'

--- a/src/test/classes/TestAuth.php
+++ b/src/test/classes/TestAuth.php
@@ -390,7 +390,8 @@ class TestAuth extends TestCase
     public function newUserFailsForEmptyUser() {
         $data = [
             'user_name' => '',
-            'password' => 'password'
+            'password' => 'Test1234!',
+            'email' => 'test@example.org'
         ];
 
         $dbo = $this->getMockBuilder(DBO::class)

--- a/src/test/classes/TestAuth.php
+++ b/src/test/classes/TestAuth.php
@@ -539,7 +539,7 @@ class TestAuth extends TestCase
         $data = [
             'user_name' => 'user1',
             'email' => 'user1@example.org',
-            'password' => 'password1'
+            'password' => 'Test1234!'
         ];
         $user = (object) [
            'id' => 1,

--- a/src/test/classes/TestAuth.php
+++ b/src/test/classes/TestAuth.php
@@ -537,8 +537,8 @@ class TestAuth extends TestCase
      */
     public function newUserSuccessForNewUser() {
         $data = [
-            'user_name' => 'user1',
-            'email' => 'user1@example.org',
+            'user_name' => 'user2',
+            'email' => 'user2@example.org',
             'password' => 'Test1234!'
         ];
         $user = (object) [

--- a/src/test/classes/TestAuth.php
+++ b/src/test/classes/TestAuth.php
@@ -57,11 +57,11 @@ class TestAuth extends TestCase
             ->disableOriginalConstructor()
             ->onlyMethods(['withRedirect', 'withStatus'])
             ->getMock();
-        $response->expects($this->once())
+        $response->expects($this->never())
             ->method('withRedirect')
             ->with('path/to/login?message=invalid')
             ->willReturn($response);
-        $response->expects($this->once())
+        $response->expects($this->never())
             ->method('withStatus')
             ->with(302)
             ->willReturn($response);
@@ -71,7 +71,7 @@ class TestAuth extends TestCase
             ->disableOriginalConstructor()
             ->onlyMethods(['pathFor'])
             ->getMock();
-        $router->expects($this->once())
+        $router->expects($this->never())
             ->method('pathFor')
             ->with('login')
             ->willReturn('path/to/login');
@@ -82,8 +82,10 @@ class TestAuth extends TestCase
             ->onlyMethods(['render'])
             ->getMock();
 
-        $view->expects($this->never())
-            ->method('render');
+        $view->expects($this->once())
+            ->method('render')
+            ->with($response, 'login.html')
+            ->willReturn($response);
 
         $cookies = $this->getMockBuilder(Cookies::class)
             ->disableOriginalConstructor()
@@ -369,8 +371,10 @@ class TestAuth extends TestCase
             ->onlyMethods(['render'])
             ->getMock();
 
-        $view->expects($this->never())
-            ->method('render');
+        $view->expects($this->once())
+            ->method('render')
+            ->with($response, 'register.html')
+            ->willReturn(0);
 
         # Cookies mock
         $cookies = $this->getMockBuilder(Cookies::class)
@@ -392,7 +396,7 @@ class TestAuth extends TestCase
             ->with("Empty user or pass. Don't do that!");
 
         $auth = new Auth($view, null, $dbo, 'secret_token', $cookies, $translator);
-        $this->assertEquals(0, $auth->new_user($request, $response, $data['user_name'], $data['password']));
+        $this->assertEquals(0, $auth->new_user($request, $response, null));
     }
 
     /**
@@ -440,8 +444,10 @@ class TestAuth extends TestCase
             ->onlyMethods(['render'])
             ->getMock();
 
-        $view->expects($this->never())
-            ->method('render');
+        $view->expects($this->once())
+            ->method('render')
+            ->with($response, 'register.html')
+            ->willReturn(0);
 
         # Cookies mock
         $cookies = $this->getMockBuilder(Cookies::class)
@@ -463,7 +469,7 @@ class TestAuth extends TestCase
             ->with("Empty user or pass. Don't do that!");
 
         $auth = new Auth($view, null, $dbo, 'secret_token', $cookies, $translator);
-        $this->assertEquals(0, $auth->new_user($request, $response, $data['user_name'], $data['password']));
+        $this->assertEquals(0, $auth->new_user($request, $response, null));
     }
 
     /**
@@ -517,8 +523,10 @@ class TestAuth extends TestCase
             ->onlyMethods(['render'])
             ->getMock();
 
-        $view->expects($this->never())
-            ->method('render');
+        $view->expects($this->once())
+            ->method('render')
+            ->with($response, 'register.html')
+            ->willReturn(0);
 
         # Cookies mock
         $cookies = $this->getMockBuilder(Cookies::class)
@@ -540,7 +548,7 @@ class TestAuth extends TestCase
             ->with("User already exists");
 
         $auth = new Auth($view, null, $dbo, 'secret_token', $cookies, $translator);
-        $this->assertEquals(0, $auth->new_user($request, $response, $data['user_name'], $data['password']));
+        $this->assertEquals(0, $auth->new_user($request, $response, null));
     }
 
     /**
@@ -591,7 +599,7 @@ class TestAuth extends TestCase
             ->getMock();
         $response->expects($this->once())
             ->method('withRedirect')
-            ->with('path/to/login?newuser=1')
+            ->with('path/to/topics')
             ->willReturn($response);
         $response->expects($this->once())
             ->method('withStatus')
@@ -605,8 +613,8 @@ class TestAuth extends TestCase
             ->getMock();
         $router->expects($this->once())
             ->method('pathFor')
-            ->with('login')
-            ->willReturn('path/to/login');
+            ->with('topics')
+            ->willReturn('path/to/topics');
 
         // Twig view mock
         $view = $this->getMockBuilder(Twig::class)
@@ -622,11 +630,11 @@ class TestAuth extends TestCase
             ->onlyMethods(['set'])
             ->getMock();
 
-        $cookies->expects($this->never())
+        $cookies->expects($this->once())
             ->method('set');
 
         $auth = new Auth($view, $router, $dbo, 'secret_token', $cookies, null);
-        $this->assertEquals($response, $auth->new_user($request, $response, 'user1', 'user1@example.org', 'password'));
+        $this->assertEquals($response, $auth->new_user($request, $response, null));
     }
 
 }

--- a/src/test/classes/TestAuth.php
+++ b/src/test/classes/TestAuth.php
@@ -93,7 +93,17 @@ class TestAuth extends TestCase
         $cookies->expects($this->never())
             ->method('set');
 
-        $auth = new Auth($view, $router, $dbo, 'secret_token', $cookies, null);
+        # Translator mock
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['trans'])
+            ->getMock();
+
+        $translator->expects($this->once())
+            ->method('trans')
+            ->with("Invalid username or password.");
+
+        $auth = new Auth($view, $router, $dbo, 'secret_token', $cookies, $translator);
         $this->assertEquals($response, $auth->authenticate($request, $response, null));
     }
 
@@ -109,7 +119,8 @@ class TestAuth extends TestCase
         $user = (object) [
            'id' => 101,
            'name' => $data['user_name'],
-           'valid' => true
+           'valid' => true,
+           'active' => true,
         ];
 
         $payload = array("is_admin" => false, "userid" => $user->id);
@@ -197,7 +208,8 @@ class TestAuth extends TestCase
         $user = (object) [
            'id' => 1,
            'name' => $data['user_name'],
-           'valid' => true
+           'valid' => true,
+           'active' => true,
         ];
 
         $payload = array("is_admin" => true, "userid" => $user->id);

--- a/src/test/classes/TestDBO.php
+++ b/src/test/classes/TestDBO.php
@@ -525,7 +525,7 @@ class TestDBO extends TestCase
         }
         self::$pdo->query($sql);
         $dbo = new DBO(self::$pdo);
-        $ret = $dbo->addUser('user1', 'blah', 'user1@example.org');
+        $ret = $dbo->addUser('user1', 'user1@example.org', 'Test1234!');
         $this->assertTrue(is_string($ret));
     }
 
@@ -548,7 +548,7 @@ class TestDBO extends TestCase
         }
         self::$pdo->query($sql);
         $dbo = new DBO(self::$pdo);
-        $ret = $dbo->addUser('newuser', 'Test1234!', 'newuser@example.org');
+        $ret = $dbo->addUser('newuser', 'newuser@example.org', 'Test1234!');
         $this->assertEquals(106, $ret);
         $sql = "SELECT password
                   FROM participant

--- a/src/test/classes/TestDBO.php
+++ b/src/test/classes/TestDBO.php
@@ -146,14 +146,14 @@ class TestDBO extends TestCase
         $this->_setupLocations($locations, true);
 
         // Create the users, but don't forget the special admin user
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '*14E65567ABDB5135D0CFD9A70B3032C179A49EE7')";
+                $sql .= ",({$id}, 'user{$count}', '*14E65567ABDB5135D0CFD9A70B3032C179A49EE7', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '*14E65567ABDB5135D0CFD9A70B3032C179A49EE7')";
+                $sql .= "(1, 'admin', '*14E65567ABDB5135D0CFD9A70B3032C179A49EE7', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -510,16 +510,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function addUserFailsForExistingUser() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -533,16 +533,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function addUserSucceedsForNewUser() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -563,16 +563,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function authenticateFailsForEmptyPassword() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -586,16 +586,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function authenticateFailsForEmptyUser() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -609,16 +609,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function authenticateFailsForUnknownUser() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -632,16 +632,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function authenticateFailsForWrongPassword() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -655,16 +655,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function authenticateSucceedsForKnownUser() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -732,16 +732,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function changePasswordChangesPassword() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -763,16 +763,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function changePasswordFailsForNonExistentUser() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -818,16 +818,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function checkForUserReturnsFalseForUserThatDoesntExist() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);
@@ -840,16 +840,16 @@ class TestDBO extends TestCase
      * @test
      */
     public function checkForUserReturnsTrueForUserThatExists() {
-        $sql = "INSERT INTO participant (id, name, password) VALUES";
+        $sql = "INSERT INTO participant (id, name, password, email) VALUES";
         $users = 5;
         $pass = password_hash('password', PASSWORD_DEFAULT, ['cost' => 5]);
         for ($count = 0; $count <= $users; $count++) {
             if ($count != 0) {
                 $id = $count + 100;
-                $sql .= ",({$id}, 'user{$count}', '{$pass}')";
+                $sql .= ",({$id}, 'user{$count}', '{$pass}', 'user{$count}@example.org')";
             }
             else {
-                $sql .= "(1, 'admin', '{$pass}')";
+                $sql .= "(1, 'admin', '{$pass}', 'admin@example.org')";
             }
         }
         self::$pdo->query($sql);

--- a/src/test/classes/TestDBO.php
+++ b/src/test/classes/TestDBO.php
@@ -407,6 +407,7 @@ class TestDBO extends TestCase
         $sql = str_replace("int(10)  NOT NULL", "INTEGER NOT NULL", $sql);
         $sql = str_replace("AUTO_INCREMENT", "", $sql);
         $sql = str_replace("DEFAULT", "", $sql);
+        $sql = str_replace("NOT NULL", "", $sql);
         $sql = str_replace("CHARACTER SET latin1 ", "", $sql);
         $sql = str_replace("ENGINE=InnoDB", "", $sql);
         $sql = str_replace("ENGINE=MyISAM", "", $sql);

--- a/src/test/classes/TestDBO.php
+++ b/src/test/classes/TestDBO.php
@@ -548,7 +548,7 @@ class TestDBO extends TestCase
         }
         self::$pdo->query($sql);
         $dbo = new DBO(self::$pdo);
-        $ret = $dbo->addUser('newuser', 'blah', 'newuser@example.org');
+        $ret = $dbo->addUser('newuser', 'Test1234!', 'newuser@example.org');
         $this->assertEquals(106, $ret);
         $sql = "SELECT password
                   FROM participant
@@ -556,7 +556,7 @@ class TestDBO extends TestCase
         $query = self::$pdo->prepare($sql);
         $query->execute();
         $pass = $query->fetch(PDO::FETCH_OBJ);
-        $this->assertTrue(password_verify('blah', $pass->password));
+        $this->assertTrue(password_verify('Test1234!', $pass->password));
     }
 
     /**

--- a/src/test/classes/TestDBO.php
+++ b/src/test/classes/TestDBO.php
@@ -525,7 +525,7 @@ class TestDBO extends TestCase
         }
         self::$pdo->query($sql);
         $dbo = new DBO(self::$pdo);
-        $ret = $dbo->addUser('user1', 'blah');
+        $ret = $dbo->addUser('user1', 'blah', 'user1@example.org');
         $this->assertTrue(is_string($ret));
     }
 
@@ -548,7 +548,7 @@ class TestDBO extends TestCase
         }
         self::$pdo->query($sql);
         $dbo = new DBO(self::$pdo);
-        $ret = $dbo->addUser('newuser', 'blah');
+        $ret = $dbo->addUser('newuser', 'blah', 'newuser@example.org');
         $this->assertEquals(106, $ret);
         $sql = "SELECT password
                   FROM participant


### PR DESCRIPTION
there are some changes I committed in the past months, but forgot to update the tests as well.
Mainly adding email address to the user during creation, and instead of redirecting directly rendering the desired content.
Also we are now using test passwords that fit the password policy.